### PR TITLE
Update mongoose version in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "express": "^5.0.0-alpha.1",
     "express-session": "^1.9.3",
     "jade": "^1.8.2",
-    "mongoose": "^3.8.21",
+    "mongoose": "^4.4.12",
     "request": "^2.51.0"
   }
 }


### PR DESCRIPTION
Current mongoose version(3.8.21) occurred below bugs.

```
> kerberos@0.0.4 install /home/smilo/Working/private/yahoo-oauth2-tutorial/node_modules/mongoose/node_modules/mongodb/node_modules/kerberos
> (node-gyp rebuild 2> builderror.log) || (exit 0)

make: Entering directory '/home/smilo/Working/private/yahoo-oauth2-tutorial/node_modules/mongoose/node_modules/mongodb/node_modules/kerberos/build'
  SOLINK_MODULE(target) Release/obj.target/kerberos.node
  COPY Release/kerberos.node
make: Leaving directory '/home/smilo/Working/private/yahoo-oauth2-tutorial/node_modules/mongoose/node_modules/mongodb/node_modules/kerberos/build'

> bson@0.2.22 install /home/smilo/Working/private/yahoo-oauth2-tutorial/node_modules/mongoose/node_modules/mongodb/node_modules/bson
> (node-gyp rebuild 2> builderror.log) || (exit 0)

make: Entering directory '/home/smilo/Working/private/yahoo-oauth2-tutorial/node_modules/mongoose/node_modules/mongodb/node_modules/bson/build'
  CXX(target) Release/obj.target/bson/ext/bson.o
bson.target.mk:88: recipe for target 'Release/obj.target/bson/ext/bson.o' failed
make: Leaving directory '/home/smilo/Working/private/yahoo-oauth2-tutorial/node_modules/mongoose/node_modules/mongodb/node_modules/bson/build'
```

So I updated it to 4.4.12.
